### PR TITLE
Fix README.md - add .py extension to command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ screen -R <name screen whatever you want>
 ### Start Program
 
 ```bash
-pipenv run python __main__
+pipenv run python __main__.py
 ```
 
 ## Using with Docker


### PR DESCRIPTION
Change "`pipenv run python __main__`" to "`pipenv run python __main__.py`"