### PR TITLE
Update plane1.ini.example

### DIFF
--- a/configs/plane1.ini.example
+++ b/configs/plane1.ini.example
@@ -52,7 +52,7 @@ ROOM_ID = -100xxxxxxxxxx
 BOT_TOKEN = xxxxxxxxxx:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 [MASTODON]
-ENABLE = TRUE
+ENABLE = FALSE
 ACCESS_TOKEN = mastodonaccesstoken
 APP_URL = mastodonappurl
 


### PR DESCRIPTION
Changed the MASTODON config from 'Enable = TRUE' to 'ENABLE = FALSE', as this was throwing off my initial run of the program and could be a headache for other users too. Changing this also aligns it with the other services who are set to 'FALSE' in the example.