### PR TITLE
Fixed out of range error when doing first time setup

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -46,10 +46,10 @@ for file in required_files:
 			print(f"Successfully got {file_name}")
 	else:
 		print(f"Already have {file_name} continuing")
-if os.path.isfile("./dependencies/" + required_files[4][0]) and not os.path.isfile("./dependencies/aircrafts.json"):
+if os.path.isfile("./dependencies/" + required_files[3][0]) and not os.path.isfile("./dependencies/aircrafts.json"):
     print("Extracting Mictronics DB")
     from zipfile import ZipFile
-    with ZipFile("./dependencies/" + required_files[4][0], 'r') as mictronics_db:
+    with ZipFile("./dependencies/" + required_files[3][0], 'r') as mictronics_db:
         mictronics_db.extractall("./dependencies/")
 
 main_config = configparser.ConfigParser()


### PR DESCRIPTION
Fixes a bug that was introduced in https://github.com/Jxck-S/plane-notify/pull/119

https://github.com/Jxck-S/plane-notify/pull/119 removed references to adsbx screenshot but forgot to update the array index references in the code. The `required_files` array currently has 4 items but lines 49 and 52 were trying to get a fifth item from it.